### PR TITLE
Add port freeing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It tells you *before* your container says "Port already in use".
 - 🚫 Ignores ports already used by containers from the **same compose file**.
 - ✅ Friendly output: “All good” or conflict details.
 - 🛑 Optionally free a specified port that's currently in use.
+- 🤖 Non-interactive mode via `--yes` or `PORTSCOPE_YES=1`.
 
 ---
 
@@ -59,6 +60,7 @@ portscope custom.yml        # Parse a specific file directly
 
 ```bash
 portscope --free-port 8080  # Try to free port 8080
+portscope --free-port 8080 --yes  # Free port 8080 without prompts
 portscope --help            # Show help message
 portscope --version         # Show version number
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Simple. Fast. No surprises.
 
 - Bash
 - `ss` (part of `iproute2` package)
-- Docker CLI
+- Docker CLI (optional for `--free-port`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It tells you *before* your container says "Port already in use".
 - ⚠️ Detects conflicts with system ports (used by other services or Docker).
 - 🚫 Ignores ports already used by containers from the **same compose file**.
 - ✅ Friendly output: “All good” or conflict details.
-- 🛑 Optionally free a port that's currently in use.
+- 🛑 Optionally free a specified port that's currently in use.
 
 ---
 
@@ -58,9 +58,9 @@ portscope custom.yml        # Parse a specific file directly
 ### ℹ️ Extras
 
 ```bash
+portscope --free-port 8080  # Try to free port 8080
 portscope --help            # Show help message
 portscope --version         # Show version number
-portscope --free-port 8080  # Try to free port 8080
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It tells you *before* your container says "Port already in use".
 - ⚠️ Detects conflicts with system ports (used by other services or Docker).
 - 🚫 Ignores ports already used by containers from the **same compose file**.
 - ✅ Friendly output: “All good” or conflict details.
+- 🛑 Optionally free a port that's currently in use.
 
 ---
 
@@ -59,6 +60,7 @@ portscope custom.yml        # Parse a specific file directly
 ```bash
 portscope --help            # Show help message
 portscope --version         # Show version number
+portscope --free-port 8080  # Try to free port 8080
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add `--free-port` command for interactively freeing ports
- document new option in README
- bump version to 1.2.0

## Testing
- `shellcheck portscope.sh`
- `bash portscope.sh --help` *(fails: Required command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_6884cfb65ef08323b6316d15a65d35b5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to free a port currently in use, allowing users to stop the process or Docker container occupying a specified port.
  * Introduced a non-interactive mode with a `--yes` flag or environment variable to auto-confirm prompts.
* **Documentation**
  * Updated the README with details and usage examples for the new port-freeing and non-interactive features.
* **Chores**
  * Updated the script version to 1.2.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->