### PR TITLE
Add --free alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ portscope custom.yml        # Parse a specific file directly
 
 ```bash
 portscope --free-port 8080  # Try to free port 8080
+portscope --free 8080       # Same as above using alias
 portscope --free-port 8080 --yes  # Free port 8080 without prompts
 portscope --help            # Show help message
 portscope --version         # Show version number
@@ -95,7 +96,7 @@ Simple. Fast. No surprises.
 
 - Bash
 - `ss` (part of `iproute2` package)
-- Docker CLI (optional for `--free-port`)
+- Docker CLI (optional for `--free-port` or `--free`)
 
 ---
 

--- a/portscope.sh
+++ b/portscope.sh
@@ -32,7 +32,8 @@ Check if ports defined in a docker-compose.yml file are already in use.
 Options:
   --help        Show this help message
   --version     Show version information
-  --free-port N Attempt to free port N if it is in use
+  --free-port N
+  --free N      Attempt to free port N if it is in use
   --yes         Assume "yes" for all prompts
 EOF
 }
@@ -232,7 +233,7 @@ case "$1" in
         show_version
         exit 0
         ;;
-    --free-port)
+    --free-port|--free)
         shift
         check_requirements ss awk grep ps kill
         free_port "$1"


### PR DESCRIPTION
## Summary
- add `--free` alias for port freeing
- show new alias in help output
- mention alias in README examples and requirements

## Testing
- `bash -n portscope.sh`
- `bash portscope.sh --help | head -n 20`
- `bash portscope.sh --free 1 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6885f1b56eac8323b261b9ff399d2e25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line alias --free as an alternative to --free-port for freeing a specified port.

* **Documentation**
  * Updated the README to document the new --free alias and clarified Docker CLI requirements for both options.
  * Improved help message to include the --free option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->